### PR TITLE
updating all lecture notes to use LaTeX

### DIFF
--- a/Lectures/Trees.md
+++ b/Lectures/Trees.md
@@ -27,9 +27,9 @@ A **binary search tree** (BST) is a binary tree that has a couple extra constrai
 
 ![binary search tree](../images/binarysearchtree.jpeg)
 
-Binary search trees are good candidates for implementing sets and maps, and in an optimally balanced tree, we have guaranteed `O(log n)` time operations (lookup, insert, remove), where `n` is the number of elements.
+Binary search trees are good candidates for implementing sets and maps, and in an optimally balanced tree, we have guaranteed $O(\log (n))$ time operations (lookup, insert, remove), where $n$ is the number of elements.
 
-However, if the tree is unbalanced enough, we end up with a sorted linked list and regress back to `O(n)` time operations where `n` is the number of elements.
+However, if the tree is unbalanced enough, we end up with a sorted linked list and regress back to $O(n)$ time operations where $n$ is the number of elements.
 
 ## Using the Tree: Traversals
 In order to gain value from the sorted property, we must be able to use the tree in a way that takes advantage of its properties.

--- a/Lectures/arraylists_vectors.md
+++ b/Lectures/arraylists_vectors.md
@@ -157,10 +157,10 @@ In this class, we'll (mostly) discuss Abstract Data Types (ADTs)
 * An ADT outlines a set of behaviors that should be expected, but not how to implement them.
 * Implementation can vary wildly, providing the behavior is as expected.
 
-A data structure is a set implementation.
+A data structure is an implementation.
 * They are defined in terms of how they are implemented, not behavior.
 
-Think of ADTs as an Interface, and data structures as a class.
+Think of ADTs as an interface, and data structures as a class.
 
 Example data structures:
 * Arrays, LinkedLists, ArrayLists...
@@ -176,7 +176,7 @@ Now back to the main content.
 * The C++ equivalent (that you will be making in the assignment) is called a Vector ([`std::vector`](http://www.cplusplus.com/reference/vector/vector/?kw=vector))
 * By default, Java ArrayLists can hold elements that are not all the same type, but C++ Vectors cannot.
 
-  *side note: Java also has Vectors [`java.util.Vector`](https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html) and the difference is that the Java Vectors are thread-safe while vectors aren't*
+  *side note: Java also has Vectors [`java.util.Vector`](https://docs.oracle.com/javase/8/docs/api/java/util/Vector.html) and the difference is that the Java Vectors are thread-safe while ArrayLists aren't*
 
 * The main functions implemented are: `size` (returns the number of elements), `empty`, `operator[]/at` (access an element),
   `front` (access first element), `back` (access last element), `push_back` (add to end), `pop_back` (remove from end), and
@@ -186,17 +186,17 @@ Now back to the main content.
 
 What's the runtime of...
 
-`size`? <!--- runtime of size is O(1) --->
+`size`? <!-- runtime of size is $O(1)$ -->
 
-`empty`? <!--- runtime of empty is O(1) --->
+`empty`? <!-- runtime of empty is $O(1)$ -->
 
-`operator[]/at` and `front` and `back`? <!--- runtime of this is also O(1) --->
+`operator[]/at` and `front` and `back`? <!-- runtime of this is also $O(1)$ -->
 
-`pop_back`? <!--- runtime of this is O(1) --->
+`pop_back`? <!-- runtime of this is $O(1)$ -->
 
-`insert`? <!--- Runtime is linear on the number of elements inserted + number of elements after position --->
+`insert`? <!-- Runtime is linear on the number of elements inserted + number of elements after position -->
 
-`push_back`? <!--- This one they won't get; runtime is O(1) amortized time where a reallocation is linear time up to the size --->
+`push_back`? <!-- This one they won't get; runtime is $O(1)$ amortized time where a reallocation is linear time up to the size -->
 
 
 To fully understand the runtime of `push_back`, wait until an advanced algorithms class where *amortization* is discussed. We won't

--- a/Lectures/hashing.md
+++ b/Lectures/hashing.md
@@ -1,16 +1,16 @@
 # Introduction to Hashing
 ### Chapter 5 of _Data Structures and Algorithm Analysis in C++_
 
-![hashmap](../images/hashtable.jpeg)
+![hashtable](../images/hashtable.jpeg)
 
 ## The Motivation
 So far, we've looked at lists and arrays for storage.
 
-We know that to find an arbitrary element in an unsorted array or list, it takes `O(n)` time on average where `n` is the number of elements.
+We know that to find an arbitrary element in an unsorted array or list, it takes $O(n)$ time on average where $n$ is the number of elements.
 
-Our goal is to go from `O(n)` to `O(1)` time average case. How can we do this?
+Our goal is to go from $O(n)$ to $O(1)$ time average case. How can we do this?
 
-The idea: take our data, run it through a function, use the output to help us store/locate our data. This gives us, ignoring the computation time for the function itself, a `O(1)` lookup and insert.
+The idea: take our data, run it through a function, use the output to help us store/locate our data. This gives us, ignoring the computation time for the function itself, a $O(1)$ lookup and insert.
 
 ## Hashing & Hash Functions
 This is the idea of turning some data into a number via a function, called a *hash function*.
@@ -19,18 +19,18 @@ This can be done for both cryptography (cryptographic hashing) or for speed (reg
 
 For non-cryptographic hash functions, there are two main properties:
 
-Given two values *k* and *l* and a hash function *h(x)*:
-1. **Property of Equality** (required): if *k* equals *l*, then *h(k)* equals *h(l)*.
-   * This property is required since without it, our function becomes useless for searching and puts us back to `O(n)` search.
-2. **Property of Inequality** *(optional)*: if *k* does not equal *l*, then *h(k)* does not equal *h(l)*
-   * This property guarantees unique hashes, and is nice to have since it leads to perfect optimal `O(1)` search and insertion.
+Given two values $k$ and $l$ and a hash function $h(x)$:
+1. **Property of Equality** (required): $$k = l \Rightarrow h(k) = h(l)$$.
+   * This property is required since without it, our function becomes useless for searching and puts us back to $O(n)$ search.
+2. **Property of Inequality** *(optional)*: $$k \neq l \Rightarrow h(k) \neq h(l)$$
+   * This property guarantees unique hashes, and is nice to have since it leads to perfect optimal $O(1)$ search and insertion.
 
 A function that has both of these properties is known as a **perfect hash function**, and are generally hard to come up with. 
 
-(For you mathematicians, a perfect hash function is also known as an injective (or one-to-one) function where each distinct element of the domain maps to one and only one element of the codomain).
+(For you mathematicians, a perfect hash function is also known as an *injective* (a.k.a. one-to-one) function where each distinct element of the domain maps to one and only one element of the codomain).
 
 <br><br>
-**Discuss**: Is the function *f(x) = 0* a hash function? Is it perfect?
+**Discuss**: Is the function $f(x) = 0$ a hash function? Is it perfect?
 <br><br>
 
 **Answer**: *Yes*! It's just not a useful hash function. It also isn't a perfect hash function.
@@ -40,7 +40,7 @@ If you check both properties, you'll see that property 1 is satisfied (making it
 For practical applications, a perfect hash function may not compute any colliding elements, but we're still limited by one main factor: **_memory_**. We bound by the amount of memory, so we'll need to do a modulo (%) to stay in bounds.
 
 This can lead to interesting issues with implementation regarding the tables. If our hash function doesn't distribute well,
-we can run into problems with distribution leading to a ton of collisions. One mitigation strategy is using prime numbers for our table sizes (why is this?), while another is making sure our functions are good enough at randomly distributing data. However, this still isn't foolproof.
+we can run into problems with distribution leading to a ton of collisions. One mitigation strategy is using prime numbers for our table sizes (why would this help?), while another is making sure our functions are good enough at randomly distributing data. However, this still isn't foolproof.
 
 This means that **even with a perfect hash function, we will still have collisions in practice**. How do we deal with this?
 
@@ -80,21 +80,21 @@ We'll discuss 4 collision resolution schemes:
 ### Side Note: Performance
 One thing we've seen with all above strategies is that they all become much worse performance wise if the table gets full. This is because as the table fills, collisions become more and more likely due to the modulo operation.
 
-As a result, a common strategy is to resize the table and rehash the elements once a certain threshold is reached to maintain optimal performance. The ratio used to determine this is called **load factor** (# of elements/# of spots).
+As a result, a common strategy is to resize the table and rehash the elements once a certain threshold is reached to maintain optimal performance. The ratio used to determine this is called **load factor**: $$\text{load factor} = \frac{\text{number of elements}}{\text{number of spots}}$$
 
-A common load factor used that straddles the line between costly rehashes and costly lookups is 0.75. The lower the number, the more often the rehashes. The higher, the more often the collisions.
+A common load factor used that straddles the line between costly rehashes and costly lookups is $0.75$. The lower the number, the more often the rehashes. The higher, the more often the collisions.
 
 ## ADTs and Data Structures
-The concept of hashing allows for easy `O(1)` runtimes for the **Set** and **Map** ADTs.
+The concept of hashing allows for easy $O(1)$ runtimes for the **Set** and **Map** ADTs.
 
-A Set is an abstraction of the mathematical concept, where each item is unique.
+A **Set** is an abstraction of the mathematical concept, where each item is unique.
 
-A Map is an abstraction where key-value pairs are held, where each key must be unique. The key is used to "map" to its corresponding value.
+A **Map** is an abstraction where key-value pairs are held, where each key must be unique. The key is used to "map" to its corresponding value.
 
-Sets can be implemented with a Hashtable data structure, and Maps can be implemented with a Hashmap data structure.
+Sets can be implemented with a hashtable data structure, and Maps can be implemented with a hashmap data structure.
 
 Most languages feature support for these structures built into their libraries:
-* Python: dictionaries and sets
+* Python: `sets` and `dictionaries`
 * Java: `java.util.HashSet` and `java.util.HashMap`
 * C++: `std::unordered_set` and `std::unordered_map`
 

--- a/Lectures/heaps_pqs.md
+++ b/Lectures/heaps_pqs.md
@@ -23,18 +23,18 @@ A **priority queue** is an ADT that supports, at a minimum, *push*, *top*, and *
 
 The goal is that you are able to top the element with the highest priority in constant time, but you make no guarantees about the inherent ordering of the rest of the elements.
 
-We *could* technically implement this via a sorted linked list, but this gives us `O(n)` insertion time for `O(1)` pop and top time. While this seems okay, we'd like to be able to get better insertion time (at the cost of some pop time).
+We *could* technically implement this via a sorted linked list, but this gives us $O(n)$ insertion time for $O(1)$ pop and top time. While this seems okay, we'd like to be able to get better insertion time (at the cost of some pop time).
 
-A better option is to used a BST (or a balanced BST). The former gives us `O(log n)` average for all operations, while the latter gives us `O(log n)` worst case for all operations.
-This is fine, and it works, but we want to get back to `O(1)` pop time while keeping `O(log n)` time for all other operations.
+A better option is to used a BST (or a balanced BST). The former gives us $O(\log n)$ average for all operations, while the latter gives us $O(\log n)$ worst case for all operations.
+This is fine, and it works, but we want to get back to $O(1)$ pop time while keeping $O(\log n)$ time for all other operations.
 
 ## Implementing a Priority Queue: Heap Data Structure
 
 Often, priority queues are implemented via a **heap** data structure.
 
-*Note: this is not the same "heap" as the area of the C++ runtime. You'll learn about that in CSE 30.*
+*Note: this is not the same "heap" as the area of the C/C++/other languages' runtime environments. You'll learn about that in CSE 30.*
 
-*Note: Though other kinds of heaps exist, we're only talking here about binary heaps. If you'd like, you can learn about [fibonacci heaps and binomial heaps from this video](https://www.youtube.com/watch?v=gxp_FrgTkQI).*
+*Another note: Though other kinds of heaps exist, we're only talking here about binary heaps. If you'd like, you can learn about [fibonacci heaps and binomial heaps from this video](https://www.youtube.com/watch?v=gxp_FrgTkQI).*
 
 A *binary heap* is a binary tree with a couple extra properties:
 1. **Full Heap Property**
@@ -60,18 +60,18 @@ Is the following heap a min heap, or a max heap?
 
 Because of property 1, implementing a heap via an array is actually pretty easy to do. We can very easily map each index of an array to a child of a node via a few formulas. The book doesn't use index 0 of the array, so their formulas will be different by a factor of 1.
 
-For any index *i*:
+For any index $i$:
 * To find the parent
-  * using index 0: **(i - 1) / 2** (integer division!)
-  * not using index 0: **i / 2** (integer division!)
+  * using index 0: $(i - 1) / 2$ (**_integer division!_**)
+  * not using index 0: $i / 2$ (**_integer division!_**)
 * To find the left child
-  * using index 0: **(2 * i) + 1**
-  * not using index 0: **(2 * i) + 2**
+  * using index 0: $(2 \times i) + 1$
+  * not using index 0: $(2 \times i) + 2$
 * To find the right child
-  * using index 0: **(2 * i) + 2**
-  * not using index 0: **(2 * i) + 1**
+  * using index 0: $(2 \times i) + 2$
+  * not using index 0: $(2 \times i) + 1$
 
-For all formulas, unsigned integer types should be used to verify that values below 0 are never indexed into.
+#### For all formulas, unsigned integer types should be used to verify that values below 0 are never indexed into.
 
 Here's an example of using an array:
 ![array heap](../images/binaryheapwarrayrepr.png)

--- a/Lectures/intro.md
+++ b/Lectures/intro.md
@@ -132,32 +132,32 @@ programming language used to implement the algo, quality of the operating system
 Solution: Quantify our algorithm speed and space in terms of *abstract operations*
 
 *Note: We won't get into the details (I'll leave that for CSE 21 and 101) but this will be a quick and dirty intro.*
-*In general, we will talk about the average case upper bound (aka big O), but other measures exist.*
+*In general, we will talk about the average case upper bound (aka big $O$), but other measures exist.*
 
 Here's a table to build intuition about kinds of runtime:
 
-Adjective | O-notation | Sample operation
+Adjective | $O$-notation | Sample operation
 :---: | :---: | :---:
-constant | O(1) | adding two `int` values
-logarithmic | O(log n) | binary search
-linear | O(n) | iterating through an array
-linearithmic | O(n log n) | merge sort
-quadratic | O(n<sup>2</sup>) | bubble sort
-cubic | O(n<sup>3</sup>) | naïve matrix multiplication
-exponential | O(x<sup>n</sup>), for x > 1 | naïve Fibonacci is ~2<sup>n</sup>
-just no | O(n<sup>n</sup>) | ??? I don't even have an example
+constant | $O(1)$ | adding two `int` values
+logarithmic | $O(\log(n))$ | binary search
+linear | $O(n)$ | iterating through an array
+linearithmic | $O(n\log (n))$ | merge sort
+quadratic | $O(n^2)$ | bubble sort
+cubic | $O(n^3)$ | naïve matrix multiplication
+exponential | $O(x^n)$, for $x \gt 1$ | naïve Fibonacci is ~2<sup>n</sup>
+just no | $O(n^n)$ | ??? I don't even have an example
 
 Here's a table to build intuition in concrete units of time:
 
 F(n) | n = 256 | n = 1024 | n = 1,048,576
 :---: | :---: | :---: | :---:
-1 | 1 µsec | 1 µsec | 1 µsec
-log<sub>2</sub>n | 8 µsec | 10 µsec | 20 µsec
-n | 256 µsec | 1.02 ms | 1.05 sec
-n log<sub>2</sub>n | 2.05 ms | 10.2 ms | 21 sec
-n<sup>2</sup> | 65.5 ms | 1.05 sec | 1.8 weeks
-n<sup>3</sup> | 16.8 sec | 17.9 min | 36,559 years
-2<sup>n</sup> | 3.7x10<sup>63</sup> years | 5.7x10<sup>294</sup> years | 2.1x10<sup>315639</sup> years
+$1$ | 1 µsec | 1 µsec | 1 µsec
+$\log_2n$ | 8 µsec | 10 µsec | 20 µsec
+$n$ | 256 µsec | 1.02 ms | 1.05 sec
+$n\log_2n$ | 2.05 ms | 10.2 ms | 21 sec
+$n^2$| 65.5 ms | 1.05 sec | 1.8 weeks
+$n^3$ | 16.8 sec | 17.9 min | 36,559 years
+$2^n$ | $3.7\times10^{63}$ years | $5.7\times10^{294}$ years | $2.1\times10^{315,639}$ years
 
 Calculating Runtime:
 1. Sum up the operation in terms of how much time each step takes
@@ -183,7 +183,7 @@ Third line does integer addition, which is constant time.
 Fifth line prints to the screen, which we'll say is constant time.
 Last line returns the value, another constant time operation.
 
-Total runtime: O(1) + O(n) + O(1) + O(1) + O(1) = O(n) = linear time
+Total runtime: $O(1)$ + $O(n)$ + $O(1)$ + $O(1)$ + $O(1)$ = $O(n)$ = linear time
 
 What about this one?
 ```cpp
@@ -199,14 +199,14 @@ int errogate(int n) {
   return sum;
 }
 ```
-Total runtime: O(1) + O(n) + O(n) + O(1) + O(1) + O(1) = O(2n) = O(n) = linear time
+Total runtime: $O(1)$ + $O(n)$ + $O(n)$ + $O(1)$ + $O(1)$ + $O(1)$ = $O(2n)$ = $O(n)$ = linear time
 
-So, do problems with the same big-O runtime take the same amount of time?
+So, do problems with the same big-O runtime take the same amount of time? <!-- answer: not necessarily! -->
 
 Try this one on your own:
 ```cpp
 int mystery(int n) {
-  int count;
+  int count = 0;
   for(int i = 1; i <= n; i *= 2) {
     for(int j = 0; j < n; j++) {
       count++;
@@ -216,4 +216,4 @@ int mystery(int n) {
 }
 ```
 [back](../lectures.md)
-<!--- note: answer should be O(n log n) --->
+<!-- note: answer should be $O(n \log n)$ -->

--- a/Lectures/rebalancing.md
+++ b/Lectures/rebalancing.md
@@ -129,7 +129,7 @@ How about this input (in order):
 
 1. What is the shape of this tree <!-- correct answer: perfectly balanced -->
 
-**In a naïve implementation, the tree can get so skewed due to insertion order that we end up with horrible runtimes (`O(n)`) again**.
+**In a naïve implementation, the tree can get so skewed due to insertion order that we end up with horrible runtimes ($O(n)$) again**.
 ## Options To Resolve
 The key here is that we need to verify that our trees stay balanced throughout. The easiest way to handle this is to **rebalance** the tree as we insert to maintain some standard.
 
@@ -159,7 +159,7 @@ Which of these is not a valid AVL tree?
       * used if the tree is *left-heavy*, but the right subtree is *right-heavy*.
       * Perform a left rotate on the right subtree, then a right rotate on the out of balance node.
       * ![doubleright](../images/doubleright.png)
-* We perform these rotations as needed when inserting and removing nodes to guarantee that our tree will remain as balanced as possible, ensuring `O(log n)` time for all three main operations.
+* We perform these rotations as needed when inserting and removing nodes to guarantee that our tree will remain as balanced as possible, ensuring $O(\log (n))$ time for all three main operations.
 
 <br><br>
 Try doing AVL insertion for [1,7] in that order. What shape do you get?

--- a/Lectures/stacks_queues.md
+++ b/Lectures/stacks_queues.md
@@ -20,7 +20,7 @@ Firstly, we'll talk about stacks.
 
 * What: ADT that supports three basic operations: `push`, `pop`, and `top/peek`
 
-* Why: Provides constant time O(1) access to *only* the most recently added element. Allows us to create a history of things in order that they were seen. Follows ordering of __*Last in, First Out*__ (LIFO).
+* Why: Provides constant time $O(1)$ access to *only* the most recently added element. Allows us to create a history of things in order that they were seen. Follows ordering of __*Last in, First Out*__ (LIFO).
 
 ### Use Cases
 
@@ -44,7 +44,7 @@ How would you approach this question? Discuss
 
 Solution:
 
-Create a stack. Read characters in. If you see a '(', '[', or a '{', push it onto the stack. When you see one of the closing ones, pop off of the stack and check if you have a matching pair. Once you're done reading the string, check if your stack is empty and return `true` if so. This runs in `O(n)` time where `n` is the length of the string.
+Create a stack. Read characters in. If you see a '(', '[', or a '{', push it onto the stack. When you see one of the closing ones, pop off of the stack and check if you have a matching pair. Once you're done reading the string, check if your stack is empty and return `true` if so. This runs in $O(n)$ time where `n` is the length of the string.
 
 #### Infix to Postfix
 


### PR DESCRIPTION
Now that GitHub supports $\LaTeX$ in Markdown (see the [changelog](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/)), I've now updated all of the lecture notes to use it instead of putting math stuff in code blocks.